### PR TITLE
specifying branch main since branch master is missing in the dependecy repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "cryptoconditions"
 crate-type = ["cdylib"]
 
 [dependencies]
-asn1 = { git = "https://github.com/alex/rust-asn1" }
+asn1 = { git = "https://github.com/alex/rust-asn1", branch = "main" }
 libsecp256k1 = "0.2.2"
 simple_asn1 = { git = "https://github.com/ssadler/simple_asn1" }
 num-bigint = "0.2.6"


### PR DESCRIPTION
I am working with https://github.com/dimxy/bitgo-komodo-cc-lib#build-test-app-to-run-in-nodejs

I have been receiving the following error when building :

```
cd ./node_modules/cryptoconditions-js
wasm-pack build -t nodejs
```

It turns out there is no `master` branch at the target dependency, the branch must have been renamed to main.

Error: 

```
➜  cryptoconditions-js git:(master) ✗ wasm-pack build -t nodejs
Error: Error during execution of `cargo metadata`:     Updating git repository `https://github.com/alex/rust-asn1`
error: failed to get `asn1` as a dependency of package `cryptoconditions v0.1.0 (/Users/dariah/Documents/Dev/bitgo-komodo-cc-lib/node_modules/cryptoconditions-js)`

Caused by:
  failed to load source for dependency `asn1`

Caused by:
  Unable to update https://github.com/alex/rust-asn1

Caused by:
  failed to find branch `master`

Caused by:
  cannot locate remote-tracking branch 'origin/master'; class=Reference (4); code=NotFound (-3)
```